### PR TITLE
Update current time indicator every 2 minutes.

### DIFF
--- a/client/src/calendar/Calendar.tsx
+++ b/client/src/calendar/Calendar.tsx
@@ -8,7 +8,7 @@ import SearchResults from '@/calendar/SearchResults'
 import { GlobalEvent } from '@/util/global'
 import useKeyPress from '@/lib/hooks/useKeyPress'
 
-import { ChronoUnit } from '@js-joda/core'
+import { ChronoUnit, ZonedDateTime as DateTime } from '@js-joda/core'
 import * as dates from '@/util/dates-joda'
 import { firstDayOfWeek } from '@/util/localizer-joda'
 
@@ -64,6 +64,9 @@ function Calendar() {
 
   useGlobalEventListener(GlobalEvent.refreshCalendar, handleRefreshEvent)
 
+  /**
+   * Load events for the current view.
+   */
   useEffect(() => {
     // Aborts any pending requests after the component is unmounted.
     const controller = new AbortController()
@@ -75,6 +78,17 @@ function Calendar() {
       controller.abort()
     }
   }, [calendarView.view, calendarViewUserTimezone, calendars.calendarsById, refreshId])
+
+  /**
+   * Update the time atom every 2 minutes.
+   */
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCalendarView((state) => ({ ...state, now: DateTime.now() }))
+    }, 60000 * 2)
+
+    return () => clearInterval(intervalId) // Clear interval on component unmount
+  }, [])
 
   /**
    * Keyboard shortcuts.
@@ -185,6 +199,7 @@ function Calendar() {
           events={allVisibleEvents}
           eventService={eventService}
           primaryCalendar={primaryCalendar}
+          now={calendarViewUserTimezone.now}
         />
       )
     } else if (calendarView.view == 'Month') {

--- a/client/src/calendar/DayColumn.tsx
+++ b/client/src/calendar/DayColumn.tsx
@@ -385,6 +385,7 @@ function DayColumn(props: IProps & InjectedEventActionsProps) {
       ))}
 
       <ResizeEventContainer
+        now={props.now}
         onEventUpdated={props.eventService.moveOrResizeEvent}
         slotMetrics={slotMetricsRef.current}
       >

--- a/client/src/calendar/ResizeEventContainer.tsx
+++ b/client/src/calendar/ResizeEventContainer.tsx
@@ -17,6 +17,7 @@ const GRID_WRAPPER_SELECTOR = '.cal-time-view'
 
 interface IProps {
   slotMetrics: SlotMetrics
+  now: DateTime
   children: any
   onEventUpdated: (event: Event) => void
 }
@@ -218,7 +219,6 @@ class ResizeEventContainer extends React.Component<IProps & InjectedEventActions
   public render() {
     const events = this.props.children.props.children
     const { top, height } = this.state
-    const today = DateTime.now()
     const draggingEvent = this.getDraggingEvent()
 
     return React.cloneElement(this.props.children, {
@@ -228,7 +228,7 @@ class ResizeEventContainer extends React.Component<IProps & InjectedEventActions
           {events}
           {draggingEvent && (
             <TimeGridEvent
-              now={today}
+              now={this.props.now}
               event={draggingEvent}
               label={formatTimeRange(draggingEvent.start, draggingEvent.end)}
               style={{ top, height, width: 100, xOffset: 0, border: 'none' }}

--- a/client/src/calendar/WeekHeaderRow.tsx
+++ b/client/src/calendar/WeekHeaderRow.tsx
@@ -86,7 +86,7 @@ function WeekHeaderRow(props: IProps) {
             <EventEndingRow
               segments={dayMetrics.extra}
               slots={dayMetrics.slots}
-              now={DateTime.now()}
+              now={props.now}
               eventService={props.eventService}
               onShowMore={() => props.onShowMore()}
             />

--- a/client/src/calendar/WorkWeek.tsx
+++ b/client/src/calendar/WorkWeek.tsx
@@ -11,17 +11,17 @@ import { EventService } from './event-edit/useEventService'
 interface IProps {
   events: Event[]
   date: DateTime
+  now: DateTime
   eventService: EventService
   primaryCalendar: Calendar
 }
 
 function WorkWeek(props: IProps) {
   const range = getWorkWeekRange(props.date)
-  const now = DateTime.now()
 
   return (
     <TimeGrid
-      now={now}
+      now={props.now}
       events={props.events}
       range={range}
       eventService={props.eventService}


### PR DESCRIPTION
Use the global state for the time indicator. Use time atom inside of WorkWeek & ResizeEventContainer so that it re-renders when the current time changes.